### PR TITLE
orc 1.7.4 rebuild

### DIFF
--- a/recipe/0005-fix_cmake_zlib_linking.patch
+++ b/recipe/0005-fix_cmake_zlib_linking.patch
@@ -1,0 +1,16 @@
+This patch fixes the behavior of ORC_PREFER_STATIC_ZLIB, and was corrected in 1.7.5:
+https://github.com/apache/orc/commit/1afc31d6c04729d7e194a6423c690af4519aab33
+
+--- cmake_modules/ThirdpartyToolchain.cmake	2022-04-09 14:50:16.000000000 -0700
++++ cmake_modules/zlibtest.cmake	2023-02-14 11:44:28.000000000 -0700
+@@ -145,9 +145,9 @@
+ add_library (orc_zlib INTERFACE)
+ add_library (orc::zlib ALIAS orc_zlib)
+ if (ORC_PREFER_STATIC_ZLIB AND ${ZLIB_STATIC_LIB})
+-  target_link_libraries (orc_zlib INTERFACE ${ZLIB_LIBRARY})
+-else ()
+   target_link_libraries (orc_zlib INTERFACE ${ZLIB_STATIC_LIB})
++else ()
++  target_link_libraries (orc_zlib INTERFACE ${ZLIB_LIBRARY})
+ endif ()
+ target_include_directories (orc_zlib SYSTEM INTERFACE ${ZLIB_INCLUDE_DIR})

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
     # The build system looks for lz4.lib and protobuf.lib, but our libs are
     # called liblz4.lib and libprotobuf.lib.
     - 0004-find-libs-on-windows.patch  # [win]
+    - 0005-fix_cmake_zlib_linking.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0004-find-libs-on-windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("orc", max_pin="x.x.x") }}
   ignore_run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,10 @@ requirements:
     - libprotobuf
     - cmake
   host:
-    - zlib
-    - snappy
+    - zlib 1.2.13
+    - snappy 1.1.9
     - libprotobuf
-    - lz4-c
+    - lz4-c 1.9.4
     - zstd
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
   summary: C++ libraries for Apache ORC
   dev_url: https://github.com/apache/orc
   doc_url: https://github.com/apache/orc#readme
+  description: The smallest, fastest columnar storage for Hadoop workloads.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,6 @@ build:
   number: 1
   run_exports:
     - {{ pin_subpackage("orc", max_pin="x.x.x") }}
-  ignore_run_exports:
-    # On *nix linked in statically via `-Wl,-Bstatic -lz`
-    - zlib  # [not win]
 
 requirements:
   build:


### PR DESCRIPTION
## Changes

- Added patch to correct the behavior of `ORC_PREFER_STATIC_ZLIB`.
- Added host pinnings for `zlib`, `lz4-c`, and `snappy`
- Added `description`
- Removed unneeded `ignore_run_exports`

## Notes

Without the the patch, a value of `=off` for `ORC_PREFER_STATIC_ZLIB` would wrongly cause `zlib` to be statically-linked. It now dynamically links `zlib` as expected.

This rebuild was needed to address a CVE that was found in the statically-linked `1.2.12` version of `zlib`, which was included in the previous build of `orc 1.7.4`. 
