### PR TITLE
Protobuf rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "orc" %}
 {% set version = "2.2.0" %}
 
 package:
-  name: orc
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://archive.apache.org/dist/orc/orc-{{ version }}/orc-{{ version }}.tar.gz
+  url: https://archive.apache.org/dist/{{ name }}/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: b15aca45a7e73ffbd1bbc36a78cd1422d41f07721092a25f43448e6e16f4763b
   patches:
     - patches/0001-Don-t-force-orc-to-be-a-static-library-let-end-user-.patch
@@ -16,9 +17,9 @@ source:
     - patches/0004-v2.2.0-Windows-byteswap-rename.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
-    - {{ pin_subpackage("orc", max_pin="x.x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x.x") }}
 
 requirements:
   build:
@@ -28,19 +29,19 @@ requirements:
     - cmake
     - ninja-base # [unix]
     # `protoc` is also used for building
-    - libprotobuf 5.29.3
+    - libprotobuf {{ libprotobuf }}
   host:
     - zlib {{ zlib }}
     - snappy {{ snappy }}
-    - libprotobuf 5.29.3
-    - libabseil 20250127.0 # [win] linked with orc.dll through libprotobuf dep.
+    - libprotobuf {{ libprotobuf }}
+    - libabseil {{ libabseil }} # [win] linked with orc.dll through libprotobuf dep.
     - lz4-c {{ lz4_c }}
     - zstd {{ zstd }}
   run:
     # through run exports
     - zlib        # 1.3.1
     - snappy      # 1.2.2
-    - libprotobuf # 3.5.1
+    - libprotobuf # 6.33.0
     - libabseil   # [win]
     - lz4-c       # 1.10.0
     - zstd        # 1.3.1
@@ -62,7 +63,7 @@ test:
     - if not exist %LIBRARY_INC%\orc\Common.hh exit 1  # [win]
 
 about:
-  home: https://orc.apache.org/
+  home: https://orc.apache.org
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE


### PR DESCRIPTION
orc 2.2.0

**Destination channel:** defaults

### Links

- [PKG-10696](https://anaconda.atlassian.net/browse/PKG-10696)
- [Upstream repository](https://github.com/apache/orc/tree/v2.2.0)

### Explanation of changes:

- bump build number
- add cbc pinning to protobuf
- Fix `libabseil` pinning for Windows
- Add `{{ name }}`


[PKG-10696]: https://anaconda.atlassian.net/browse/PKG-10696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ